### PR TITLE
Remove redundant IF statement

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -157,7 +157,7 @@ function createUser() {
 if [[ -z "$1" || "$1" =~ $reArgsMaybe ]]; then
     startSshd=true
 else
-    startSshd=false
+	startSshd=false
 fi
 
 # Backward compatibility with legacy config path
@@ -166,51 +166,51 @@ if [ ! -f "$userConfPath" -a -f "$userConfPathLegacy" ]; then
     ln -s "$userConfPathLegacy" "$userConfPath"
 fi
 
-# Create users only on first run
+# Create host keys only on first run
 if [ ! -f "$userConfFinalPath" ]; then
-		# Generate unique ssh keys for this container, if needed
-		if [ ! -f /config/sshd/keys/ssh_host_ed25519_key ]; then
-				echo "Generating sshd key..."
-				ssh-keygen -t ed25519 -f /config/sshd/keys/ssh_host_ed25519_key -N ''
-		fi
-		if [ ! -f /config/sshd/keys/ssh_host_rsa_key ]; then
-				echo "Generating sshd rsa key..."
-				ssh-keygen -t rsa -b 4096 -f /config/sshd/keys/ssh_host_rsa_key -N ''
-		fi
-
-		echo "Creating users..."
-    mkdir -p "$(dirname $userConfFinalPath)"
-
-    # Append mounted config to final config
-    if [ -f "$userConfPath" ]; then
-        cat "$userConfPath" | grep -v -E "$reArgSkip" > "$userConfFinalPath"
+	# Generate unique ssh keys for this container, if needed
+    if [ ! -f /config/sshd/keys/ssh_host_ed25519_key ]; then
+        echo "Generating sshd key..."
+        ssh-keygen -t ed25519 -f /config/sshd/keys/ssh_host_ed25519_key -N ''
     fi
-
-    if $startSshd; then
-        # Append users from arguments to final config
-        for user in "$@"; do
-            echo "$user" >> "$userConfFinalPath"
-        done
+    if [ ! -f /config/sshd/keys/ssh_host_rsa_key ]; then
+          echo "Generating sshd rsa key..."
+          ssh-keygen -t rsa -b 4096 -f /config/sshd/keys/ssh_host_rsa_key -N ''
     fi
+fi
 
-    if [ -n "$SFTP_USERS" ]; then
-        # Append users from environment variable to final config
-        usersFromEnv=($SFTP_USERS) # as array
-        for user in "${usersFromEnv[@]}"; do
-            echo "$user" >> "$userConfFinalPath"
-        done
-    fi
+echo "Checking for new users..."
+mkdir -p "$(dirname $userConfFinalPath)"
 
-    # Check that we have users in config
-    if [[ -f "$userConfFinalPath" && "$(cat "$userConfFinalPath" | wc -l)" > 0 ]]; then
-        # Import users from final conf file
-        while IFS= read -r user || [[ -n "$user" ]]; do
-            createUser "$user"
-        done < "$userConfFinalPath"
-    elif $startSshd; then
-        log "FATAL: No users provided!"
-        exit 3
-    fi
+# Append mounted config to final config
+if [ -f "$userConfPath" ]; then
+    cat "$userConfPath" | grep -v -E "$reArgSkip" > "$userConfFinalPath"
+fi
+
+if $startSshd; then
+    # Append users from arguments to final config
+    for user in "$@"; do
+        echo "$user" >> "$userConfFinalPath"
+    done
+fi
+
+if [ -n "$SFTP_USERS" ]; then
+    # Append users from environment variable to final config
+    usersFromEnv=($SFTP_USERS) # as array
+    for user in "${usersFromEnv[@]}"; do
+        echo "$user" >> "$userConfFinalPath"
+    done
+fi
+
+# Check that we have users in config
+if [[ -f "$userConfFinalPath" && "$(cat "$userConfFinalPath" | wc -l)" > 0 ]]; then
+    # Import users from final conf file
+    while IFS= read -r user || [[ -n "$user" ]]; do
+        createUser "$user"
+    done < "$userConfFinalPath"
+elif $startSshd; then
+    log "FATAL: No users provided!"
+    exit 3
 fi
 
 # Source custom scripts, if any


### PR DESCRIPTION
It generates a bug where if you already have the `/var/run/sftp/users.conf` file present, rebooting the container will not apply any new users pulled in from `/config/sshd/users.conf`, therefore forcing the user to either delete the container or delete the file within it.